### PR TITLE
abi bug fix + getTable function

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -19,6 +19,7 @@ module.exports = class extends Generator {
                 type: `input`,
                 name: `contractAccount`,
                 message: `Contract Account Name`,
+                validate: (input) => new RegExp('^[a-z][a-z1-5\.]{0,10}([a-z1-5]|^\.)[a-j1-5]?$').test(input) || "Contract name must only contain characters a-z 1-5 and . no greater than 13 in length."
             },
         ]
         if (!this.fullName)

--- a/generators/app/templates/scripts/create_actions/index.js
+++ b/generators/app/templates/scripts/create_actions/index.js
@@ -3,7 +3,7 @@ const path = require(`path`)
 const childProcess = require(`child_process`)
 const ejs = require(`ejs`)
 
-const contractDir = `./contract`
+const buildDir = `./build`
 const actionsDir = `./actions`
 const actionTemplatesDir = `./scripts/create_actions`
 
@@ -41,7 +41,7 @@ async function script() {
         const compile = ejs.compile(actionTemplate)
 
         const abi = JSON.parse(
-            fs.readFileSync(path.join(contractDir, `<%= moduleNameCamelCased %>.abi`)),
+            fs.readFileSync(path.join(buildDir, `<%= moduleNameCamelCased %>.abi`)),
             `utf8`,
         )
 

--- a/generators/app/templates/scripts/table.js
+++ b/generators/app/templates/scripts/table.js
@@ -3,11 +3,11 @@ const { api } = require(`../config`)
 const { getDeployableFilesFromDir } = require(`../utils`)
 
 const { CONTRACT_ACCOUNT } = process.env
-const contractDir = `./contract`
+const buildDir = `./build`
 
 async function script() {
     const tableName = process.argv[2]
-    const { abiPath } = getDeployableFilesFromDir(contractDir)
+    const { abiPath } = getDeployableFilesFromDir(buildDir)
     const abi = JSON.parse(fs.readFileSync(abiPath, `utf8`))
     const validTableNames = abi.tables
         ? abi.tables.map(({ name }) => `"${name}"`).join(` `)

--- a/generators/app/templates/utils/others.js
+++ b/generators/app/templates/utils/others.js
@@ -36,6 +36,19 @@ const sendTransaction = async args => {
     )
 }
 
+const getTable = async (tableName, scope = CONTRACT_ACCOUNT) => {
+    return await api.rpc.get_table_rows({
+      json: true,
+      code: CONTRACT_ACCOUNT,
+      scope,
+      table: tableName,
+      lower_bound: 0,
+      upper_bound: -1,
+      limit: 9999,
+      index_position: 1
+    });
+  };
+
 function getErrorDetail(exception) {
     if (exception instanceof RpcError) return JSON.stringify(exception.json, null, 2)
     return exception && exception.message
@@ -55,6 +68,7 @@ function getDeployableFilesFromDir(dir) {
 
 module.exports = {
     sendTransaction,
+    getTable,
     getErrorDetail,
     getDeployableFilesFromDir,
 }


### PR DESCRIPTION
Actions `yarn run table` and `yarn run create_actions` reference the ABI in the contractDir instead of the buildDir which I believe the ABI is now meant to hang out. 

I added a `getTable` function for use in tests folder along side `sendTransaction`
Also added some validation for the contract name. 