### PR TITLE
deleted all actions except _ prepend

### DIFF
--- a/generators/app/templates/scripts/create_actions/index.js
+++ b/generators/app/templates/scripts/create_actions/index.js
@@ -45,7 +45,13 @@ async function script() {
             `utf8`,
         )
 
-        await fs.emptyDir(actionsDir)
+        // Delete all actions except those prepended with '_' 
+        fs.readdirSync(actionsDir)
+            .filter(fileName => fileName[0] !== "_")
+            .map(fileName => path.join(actionsDir, fileName))
+            .forEach(path => fs.removeSync(path))
+
+
         abi.actions.forEach(action => {
             const data = {
                 actionName: action.name,


### PR DESCRIPTION
## Problem
Over the course of development create_actions might be run several times to reflect new ABI changes however a developer may create several very custom actions to trigger every now and then. These currently get deleted in the `yarn run create_actions` script.

## Solution
The ability to elect some custom actions in the /actions folder to remain immune from the sweep triggered by `yarn run create_actions` 

## How
Instead of the script emptying the entire folder, it will instead delete all files unless prepended with an underscore in the filename. 